### PR TITLE
feat: add connect_timeout configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ php artisan migrate
 
 ## Configuration
 
+### Timeout Configuration
+
+Laravel Textify supports two types of timeout configurations for all SMS providers:
+
+- **`timeout`**: Maximum time (in seconds) to wait for a response from the API (default: 30s)
+- **`connect_timeout`**: Maximum time (in seconds) to wait for connection establishment (default: 10s)
+
+These settings help ensure reliable SMS delivery by preventing indefinite waits when providers are slow or unreachable.
+
 ### Environment Variables
 
 Add these to your `.env` file based on the providers you want to use:
@@ -121,6 +130,7 @@ DHOROLA_API_KEY=your_api_key
 DHOROLA_SENDER_ID=your_sender_id
 DHOROLA_BASE_URI=https://api.dhorolasms.net
 DHOROLA_TIMEOUT=30
+DHOROLA_CONNECT_TIMEOUT=10
 DHOROLA_VERIFY_SSL=true
 
 # BulkSMSBD Configuration
@@ -128,6 +138,7 @@ BULKSMSBD_API_KEY=your_api_key
 BULKSMSBD_SENDER_ID=your_sender_id
 BULKSMSBD_BASE_URI=http://bulksmsbd.net
 BULKSMSBD_TIMEOUT=30
+BULKSMSBD_CONNECT_TIMEOUT=10
 BULKSMSBD_VERIFY_SSL=false
 
 # MimSMS Configuration
@@ -138,6 +149,7 @@ MIMSMS_TRANSACTION_TYPE=T
 MIMSMS_CAMPAIGN_ID=your_campaign_id
 MIMSMS_BASE_URI=https://api.mimsms.com
 MIMSMS_TIMEOUT=30
+MIMSMS_CONNECT_TIMEOUT=10
 MIMSMS_VERIFY_SSL=true
 
 # eSMS Configuration
@@ -145,6 +157,7 @@ ESMS_API_TOKEN=your_api_token
 ESMS_SENDER_ID=your_sender_id
 ESMS_BASE_URI=https://login.esms.com.bd
 ESMS_TIMEOUT=30
+ESMS_CONNECT_TIMEOUT=10
 ESMS_VERIFY_SSL=true
 
 # REVE SMS Configuration
@@ -155,6 +168,7 @@ REVESMS_SENDER_ID=your_sender_id
 REVESMS_BASE_URI=https://smpp.revesms.com:7790
 REVESMS_BALANCE_URI=https://smpp.revesms.com
 REVESMS_TIMEOUT=30
+REVESMS_CONNECT_TIMEOUT=10
 REVESMS_VERIFY_SSL=true
 
 # Alpha SMS Configuration
@@ -162,6 +176,7 @@ ALPHASMS_API_KEY=your_api_key
 ALPHASMS_SENDER_ID=your_sender_id
 ALPHASMS_BASE_URI=https://api.sms.net.bd
 ALPHASMS_TIMEOUT=30
+ALPHASMS_CONNECT_TIMEOUT=10
 ALPHASMS_VERIFY_SSL=true
 
 # ===== INTERNATIONAL PROVIDERS =====
@@ -177,6 +192,7 @@ NEXMO_API_SECRET=your_api_secret
 NEXMO_FROM=your_sender_id
 NEXMO_CLIENT_REF=your_reference
 NEXMO_TIMEOUT=30
+NEXMO_CONNECT_TIMEOUT=10
 NEXMO_VERIFY_SSL=true
 
 # ===== PACKAGE CONFIGURATION =====

--- a/config/textify.php
+++ b/config/textify.php
@@ -40,6 +40,10 @@ return [
     | plus their respective settings. Several examples have been configured
     | for you and you are free to add your own as needed.
     |
+    | Timeout Configuration:
+    | - timeout: Maximum time (in seconds) to wait for a response from the API
+    | - connect_timeout: Maximum time (in seconds) to wait for connection establishment
+    |
     | To add a custom provider, create a class extending TextifyProvider and
     | add it to this array:
     |
@@ -48,6 +52,8 @@ return [
     |     'class' => App\Services\MySmsProvider::class,
     |     'api_key' => env('MY_CUSTOM_API_KEY'),
     |     'api_secret' => env('MY_CUSTOM_API_SECRET'),
+    |     'timeout' => env('MY_CUSTOM_TIMEOUT', 30),
+    |     'connect_timeout' => env('MY_CUSTOM_CONNECT_TIMEOUT', 10),
     |     // other configuration...
     | ],
     |
@@ -71,6 +77,7 @@ return [
             'sender_id' => env('DHOROLA_SENDER_ID'),
             'base_uri' => env('DHOROLA_BASE_URI', 'https://api.dhorolasms.net'),
             'timeout' => env('DHOROLA_TIMEOUT', 30),
+            'connect_timeout' => env('DHOROLA_CONNECT_TIMEOUT', 10),
             'verify_ssl' => env('DHOROLA_VERIFY_SSL', false),
         ],
 
@@ -80,6 +87,7 @@ return [
             'sender_id' => env('BULKSMSBD_SENDER_ID'),
             'base_uri' => env('BULKSMSBD_BASE_URI', 'http://bulksmsbd.net'),
             'timeout' => env('BULKSMSBD_TIMEOUT', 30),
+            'connect_timeout' => env('BULKSMSBD_CONNECT_TIMEOUT', 10),
             'verify_ssl' => env('BULKSMSBD_VERIFY_SSL', false),
         ],
 
@@ -92,6 +100,7 @@ return [
             'campaign_id' => env('MIMSMS_CAMPAIGN_ID'),
             'base_uri' => env('MIMSMS_BASE_URI', 'https://api.mimsms.com'),
             'timeout' => env('MIMSMS_TIMEOUT', 30),
+            'connect_timeout' => env('MIMSMS_CONNECT_TIMEOUT', 10),
             'verify_ssl' => env('MIMSMS_VERIFY_SSL', false),
         ],
 
@@ -101,6 +110,7 @@ return [
             'sender_id' => env('ESMS_SENDER_ID'),
             'base_uri' => env('ESMS_BASE_URI', 'https://login.esms.com.bd'),
             'timeout' => env('ESMS_TIMEOUT', 30),
+            'connect_timeout' => env('ESMS_CONNECT_TIMEOUT', 10),
             'verify_ssl' => env('ESMS_VERIFY_SSL', false),
         ],
 
@@ -113,6 +123,7 @@ return [
             'base_uri' => env('REVESMS_BASE_URI', 'https://smpp.revesms.com:7790'),
             'balance_uri' => env('REVESMS_BALANCE_URI', 'https://smpp.revesms.com'),
             'timeout' => env('REVESMS_TIMEOUT', 30),
+            'connect_timeout' => env('REVESMS_CONNECT_TIMEOUT', 10),
             'verify_ssl' => env('REVESMS_VERIFY_SSL', false),
         ],
 
@@ -122,6 +133,7 @@ return [
             'sender_id' => env('ALPHASMS_SENDER_ID'),
             'base_uri' => env('ALPHASMS_BASE_URI', 'https://api.sms.net.bd'),
             'timeout' => env('ALPHASMS_TIMEOUT', 30),
+            'connect_timeout' => env('ALPHASMS_CONNECT_TIMEOUT', 10),
             'verify_ssl' => env('ALPHASMS_VERIFY_SSL', false),
         ],
 
@@ -141,6 +153,7 @@ return [
             'from' => env('NEXMO_FROM', 'Vonage APIs'),
             'client_ref' => env('NEXMO_CLIENT_REF'), // Optional: Custom reference for tracking
             'timeout' => env('NEXMO_TIMEOUT', 30),
+            'connect_timeout' => env('NEXMO_CONNECT_TIMEOUT', 10),
             'verify_ssl' => env('NEXMO_VERIFY_SSL', false),
         ],
     ],

--- a/src/Providers/BaseProvider.php
+++ b/src/Providers/BaseProvider.php
@@ -98,6 +98,7 @@ abstract class BaseProvider implements TextifyProviderInterface
     {
         return [
             'timeout' => $this->config['timeout'] ?? 30,
+            'connect_timeout' => $this->config['connect_timeout'] ?? 10,
             'verify' => $this->config['verify_ssl'] ?? false,
         ];
     }

--- a/tests/ConnectTimeoutTest.php
+++ b/tests/ConnectTimeoutTest.php
@@ -3,9 +3,8 @@
 declare(strict_types=1);
 
 use DevWizard\Textify\DTOs\TextifyMessage;
-use DevWizard\Textify\Providers\BaseProvider;
 use DevWizard\Textify\DTOs\TextifyResponse;
-use GuzzleHttp\Client;
+use DevWizard\Textify\Providers\BaseProvider;
 
 /**
  * Mock provider for testing connect_timeout functionality

--- a/tests/ConnectTimeoutTest.php
+++ b/tests/ConnectTimeoutTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use DevWizard\Textify\DTOs\TextifyMessage;
+use DevWizard\Textify\Providers\BaseProvider;
+use DevWizard\Textify\DTOs\TextifyResponse;
+use GuzzleHttp\Client;
+
+/**
+ * Mock provider for testing connect_timeout functionality
+ */
+class MockProvider extends BaseProvider
+{
+    protected function validateConfig(): void
+    {
+        // Mock validation - no requirements
+    }
+
+    protected function getRequiredConfigKeys(): array
+    {
+        return []; // No required keys for mock
+    }
+
+    protected function sendRequest(TextifyMessage $message): array
+    {
+        return ['status' => 'success', 'message_id' => '12345'];
+    }
+
+    protected function parseResponse(array $response): TextifyResponse
+    {
+        return new TextifyResponse(
+            success: true,
+            messageId: $response['message_id'] ?? null,
+            rawResponse: $response
+        );
+    }
+
+    public function getName(): string
+    {
+        return 'mock';
+    }
+
+    protected function getSupportedCountries(): array
+    {
+        return ['BD'];
+    }
+
+    public function getDeliveryStatus(string $messageId): string
+    {
+        return 'delivered';
+    }
+
+    public function getBalance(): float
+    {
+        return 100.0;
+    }
+
+    public function validatePhoneNumber(string $phoneNumber): bool
+    {
+        return true;
+    }
+
+    public function formatPhoneNumber(string $phoneNumber): string
+    {
+        return $phoneNumber;
+    }
+
+    public function getClientConfigForTesting(): array
+    {
+        return $this->getClientConfig();
+    }
+}
+
+it('includes connect_timeout in client configuration', function () {
+    $config = [
+        'timeout' => 25,
+        'connect_timeout' => 15,
+        'verify_ssl' => true,
+    ];
+
+    $provider = new MockProvider($config);
+    $clientConfig = $provider->getClientConfigForTesting();
+
+    expect($clientConfig)->toHaveKey('timeout', 25);
+    expect($clientConfig)->toHaveKey('connect_timeout', 15);
+    expect($clientConfig)->toHaveKey('verify', true);
+});
+
+it('uses default connect_timeout when not specified', function () {
+    $config = [
+        'timeout' => 25,
+        'verify_ssl' => true,
+    ];
+
+    $provider = new MockProvider($config);
+    $clientConfig = $provider->getClientConfigForTesting();
+
+    expect($clientConfig)->toHaveKey('timeout', 25);
+    expect($clientConfig)->toHaveKey('connect_timeout', 10); // Default value
+    expect($clientConfig)->toHaveKey('verify', true);
+});
+
+it('uses default values when no configuration provided', function () {
+    $config = [];
+
+    $provider = new MockProvider($config);
+    $clientConfig = $provider->getClientConfigForTesting();
+
+    expect($clientConfig)->toHaveKey('timeout', 30); // Default value
+    expect($clientConfig)->toHaveKey('connect_timeout', 10); // Default value
+    expect($clientConfig)->toHaveKey('verify', false); // Default value
+});


### PR DESCRIPTION
### What's Changed

#### 🚀 New Features

* **feat: add connect_timeout configuration option**
  - Added `connect_timeout` option to all SMS provider configurations
  - Updated `BaseProvider` to use `connect_timeout` in HTTP client config
  - Added comprehensive test coverage for `connect_timeout` functionality
  - Updated provider configuration documentation
  - Default `connect_timeout` is 10 seconds, configurable per provider

#### ⚡ Enhanced Provider Configuration

* **Timeout Configuration:** Providers now support two distinct timeout settings:
  - `timeout`: Maximum time (in seconds) to wait for a response from the API (default: 30s)
  - `connect_timeout`: Maximum time (in seconds) to wait for connection establishment (default: 10s)

#### 📋 Updated Providers

All SMS providers now support the new `connect_timeout` configuration:
- Dhorola SMS: `DHOROLA_CONNECT_TIMEOUT` (default: 10s)
- BulkSMSBD: `BULKSMSBD_CONNECT_TIMEOUT` (default: 10s) 
- MimSMS: `MIMSMS_CONNECT_TIMEOUT` (default: 10s)
- eSMS: `ESMS_CONNECT_TIMEOUT` (default: 10s)
- REVE SMS: `REVESMS_CONNECT_TIMEOUT` (default: 10s)
- Alpha SMS: `ALPHASMS_CONNECT_TIMEOUT` (default: 10s)
- Nexmo: `NEXMO_CONNECT_TIMEOUT` (default: 10s)

#### 🧪 Testing

* Added `ConnectTimeoutTest` with comprehensive test coverage
* Tests verify proper default values and configuration handling
* All existing tests continue to pass

### Breaking Changes

None. This is a backward-compatible feature addition.

### Migration Guide

To use the new connect_timeout feature, add the appropriate environment variable to your `.env` file:

```env
# Example for Dhorola SMS provider
DHOROLA_CONNECT_TIMEOUT=15

# Or for any other provider
BULKSMSBD_CONNECT_TIMEOUT=8
MIMSMS_CONNECT_TIMEOUT=12
```