### PR TITLE
feat: Add comprehensive message validation with configurable Laravel-style validation rules

### DIFF
--- a/config/textify.php
+++ b/config/textify.php
@@ -207,4 +207,27 @@ return [
     'events' => [
         'enabled' => env('TEXTIFY_EVENTS_ENABLED', true),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Message Validation
+    |--------------------------------------------------------------------------
+    |
+    | Configure validation rules for SMS messages before sending.
+    | Uses Laravel-style validation rules for consistency.
+    |
+    */
+
+    'validation' => [
+        'message' => [
+            // Set to false to allow empty messages
+            'required' => env('TEXTIFY_MESSAGE_REQUIRED', true),
+
+            // Minimum message length
+            'min' => env('TEXTIFY_MESSAGE_MIN_LENGTH', 1),
+
+            // Maximum message length (null = no limit)
+            'max' => env('TEXTIFY_MESSAGE_MAX_LENGTH', null),
+        ],
+    ],
 ];

--- a/src/Providers/Bangladeshi/BulkSmsBdProvider.php
+++ b/src/Providers/Bangladeshi/BulkSmsBdProvider.php
@@ -119,7 +119,6 @@ class BulkSmsBdProvider extends BaseProvider
                     '1006' => 'Balance Validity Not Available',
                     '1007' => 'Balance Insufficient',
                     '1011' => 'User Id not found',
-                    // Add more error codes as needed
                 ];
                 $errorMessage = $errorMessages[$errorCode] ?? $responseText;
             }

--- a/src/Providers/BaseProvider.php
+++ b/src/Providers/BaseProvider.php
@@ -316,7 +316,7 @@ abstract class BaseProvider implements TextifyProviderInterface
         $maxLength = config('textify.validation.message.max', null);
 
         $trimmedMessage = trim($message);
-        
+
         // Check if message is required but empty
         if ($required && empty($trimmedMessage)) {
             return [
@@ -326,7 +326,7 @@ abstract class BaseProvider implements TextifyProviderInterface
         }
 
         // Skip length validation if message is empty and not required
-        if (!$required && empty($trimmedMessage)) {
+        if (! $required && empty($trimmedMessage)) {
             return ['valid' => true];
         }
 
@@ -356,8 +356,8 @@ abstract class BaseProvider implements TextifyProviderInterface
     {
         // Basic validation - check if not empty and contains only digits, +, -, spaces, and parentheses
         $cleaned = preg_replace('/[\s\-\(\)]+/', '', $phoneNumber);
-        
-        return ! empty(trim($phoneNumber)) && 
+
+        return ! empty(trim($phoneNumber)) &&
                preg_match('/^\+?[0-9]{7,15}$/', $cleaned);
     }
 

--- a/src/Providers/BaseProvider.php
+++ b/src/Providers/BaseProvider.php
@@ -132,6 +132,15 @@ abstract class BaseProvider implements TextifyProviderInterface
                 );
             }
 
+            // Validate message content
+            $messageValidationResult = $this->validateMessageContent($message->message);
+            if (! $messageValidationResult['valid']) {
+                return TextifyResponse::failed(
+                    errorMessage: $messageValidationResult['error'],
+                    errorCode: 'INVALID_MESSAGE_CONTENT'
+                );
+            }
+
             // Format phone number
             $formattedMessage = new TextifyMessage(
                 to: $this->formatPhoneNumber($message->to),
@@ -291,5 +300,74 @@ abstract class BaseProvider implements TextifyProviderInterface
                 )
             );
         }
+    }
+
+    /**
+     * Validate message content according to configuration rules
+     *
+     * @param  string  $message  The message content to validate
+     * @return array{valid: bool, error?: string}
+     */
+    protected function validateMessageContent(string $message): array
+    {
+        // Use Laravel-style validation config structure
+        $required = config('textify.validation.message.required', true);
+        $minLength = config('textify.validation.message.min', 1);
+        $maxLength = config('textify.validation.message.max', null);
+
+        $trimmedMessage = trim($message);
+        
+        // Check if message is required but empty
+        if ($required && empty($trimmedMessage)) {
+            return [
+                'valid' => false,
+                'error' => 'The message field is required.',
+            ];
+        }
+
+        // Skip length validation if message is empty and not required
+        if (!$required && empty($trimmedMessage)) {
+            return ['valid' => true];
+        }
+
+        // Check minimum length (combines empty check with min length)
+        if (strlen($trimmedMessage) < $minLength) {
+            return [
+                'valid' => false,
+                'error' => sprintf('The message must be at least %d character%s.', $minLength, $minLength === 1 ? '' : 's'),
+            ];
+        }
+
+        // Check maximum length if specified
+        if ($maxLength !== null && strlen($trimmedMessage) > $maxLength) {
+            return [
+                'valid' => false,
+                'error' => sprintf('The message may not be greater than %d characters.', $maxLength),
+            ];
+        }
+
+        return ['valid' => true];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatePhoneNumber(string $phoneNumber): bool
+    {
+        // Basic validation - check if not empty and contains only digits, +, -, spaces, and parentheses
+        $cleaned = preg_replace('/[\s\-\(\)]+/', '', $phoneNumber);
+        
+        return ! empty(trim($phoneNumber)) && 
+               preg_match('/^\+?[0-9]{7,15}$/', $cleaned);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function formatPhoneNumber(string $phoneNumber): string
+    {
+        // Default implementation - just trim whitespace
+        // Providers should override this method for their specific formatting requirements
+        return trim($phoneNumber);
     }
 }

--- a/tests/MessageValidationTest.php
+++ b/tests/MessageValidationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DevWizard\Textify\Tests;
+
+use DevWizard\Textify\DTOs\TextifyMessage;
+use DevWizard\Textify\Providers\LogProvider;
+
+it('rejects empty messages by default (required)', function () {
+    $provider = new LogProvider([]);
+
+    $message = TextifyMessage::create('01712345678', '', 'TestSender');
+    $response = $provider->send($message);
+
+    expect($response->isSuccessful())->toBeFalse();
+    expect($response->getErrorCode())->toBe('INVALID_MESSAGE_CONTENT');
+    expect($response->getErrorMessage())->toContain('field is required');
+});
+
+it('accepts empty messages when not required (nullable)', function () {
+    // Temporarily override config to make message not required (nullable)
+    config(['textify.validation.message.required' => false]);
+    
+    $provider = new LogProvider([]);
+
+    $message = TextifyMessage::create('01712345678', '', 'TestSender');
+    $response = $provider->send($message);
+
+    expect($response->isSuccessful())->toBeTrue();
+
+    // Reset config
+    config(['textify.validation.message.required' => true]);
+});
+
+it('rejects messages shorter than minimum length', function () {
+    config(['textify.validation.message.min' => 5]);
+    
+    $provider = new LogProvider([]);
+
+    $message = TextifyMessage::create('01712345678', 'Hi', 'TestSender');
+    $response = $provider->send($message);
+
+    expect($response->isSuccessful())->toBeFalse();
+    expect($response->getErrorCode())->toBe('INVALID_MESSAGE_CONTENT');
+    expect($response->getErrorMessage())->toContain('must be at least 5 character');
+
+    // Reset config
+    config(['textify.validation.message.min' => 1]);
+});
+
+it('rejects messages longer than maximum length', function () {
+    config(['textify.validation.message.max' => 10]);
+    
+    $provider = new LogProvider([]);
+
+    $message = TextifyMessage::create('01712345678', 'This message is way too long', 'TestSender');
+    $response = $provider->send($message);
+
+    expect($response->isSuccessful())->toBeFalse();
+    expect($response->getErrorCode())->toBe('INVALID_MESSAGE_CONTENT');
+    expect($response->getErrorMessage())->toContain('may not be greater than 10 characters');
+
+    // Reset config
+    config(['textify.validation.message.max' => null]);
+});
+
+it('accepts valid messages', function () {
+    $provider = new LogProvider([]);
+
+    $message = TextifyMessage::create('01712345678', 'Valid message content', 'TestSender');
+    $response = $provider->send($message);
+
+    expect($response->isSuccessful())->toBeTrue();
+});
+
+it('validates whitespace-only messages as empty', function () {
+    $provider = new LogProvider([]);
+
+    $message = TextifyMessage::create('01712345678', '   ', 'TestSender');
+    $response = $provider->send($message);
+
+    expect($response->isSuccessful())->toBeFalse();
+    expect($response->getErrorCode())->toBe('INVALID_MESSAGE_CONTENT');
+    expect($response->getErrorMessage())->toContain('field is required');
+});

--- a/tests/MessageValidationTest.php
+++ b/tests/MessageValidationTest.php
@@ -21,7 +21,7 @@ it('rejects empty messages by default (required)', function () {
 it('accepts empty messages when not required (nullable)', function () {
     // Temporarily override config to make message not required (nullable)
     config(['textify.validation.message.required' => false]);
-    
+
     $provider = new LogProvider([]);
 
     $message = TextifyMessage::create('01712345678', '', 'TestSender');
@@ -35,7 +35,7 @@ it('accepts empty messages when not required (nullable)', function () {
 
 it('rejects messages shorter than minimum length', function () {
     config(['textify.validation.message.min' => 5]);
-    
+
     $provider = new LogProvider([]);
 
     $message = TextifyMessage::create('01712345678', 'Hi', 'TestSender');
@@ -51,7 +51,7 @@ it('rejects messages shorter than minimum length', function () {
 
 it('rejects messages longer than maximum length', function () {
     config(['textify.validation.message.max' => 10]);
-    
+
     $provider = new LogProvider([]);
 
     $message = TextifyMessage::create('01712345678', 'This message is way too long', 'TestSender');


### PR DESCRIPTION
This pull request introduces message content validation for SMS messages, ensuring that messages meet configurable requirements before being sent. The validation logic is configurable via the `textify.php` config file and is enforced in all providers. Comprehensive tests are included to verify the validation behavior for various scenarios.

**Message Validation Feature:**

* Added a new `validation` section to `config/textify.php` to configure message requirements, including whether messages are required, minimum length, and maximum length.
* Implemented the `validateMessageContent` method in `BaseProvider.php` to enforce these validation rules before sending a message. If validation fails, an error response is returned. [[1]](diffhunk://#diff-382ed6337b573ba6fcf403616f0125baf7aae5ed31d7eb1a04705ff3a3dc2d7eR135-R143) [[2]](diffhunk://#diff-382ed6337b573ba6fcf403616f0125baf7aae5ed31d7eb1a04705ff3a3dc2d7eR304-R372)

**Testing and Coverage:**

* Added `MessageValidationTest.php` to cover all key validation scenarios: required/nullable messages, minimum/maximum length, valid messages, and whitespace-only messages.

**Minor Codebase Cleanup:**

* Removed a redundant comment in the error code mapping of `BulkSmsBdProvider.php`.