### PR TITLE
fix: address review feedback on SKILL.md documentation

### DIFF
--- a/resources/boost/skills/textify/SKILL.md
+++ b/resources/boost/skills/textify/SKILL.md
@@ -338,12 +338,13 @@ class OtpController extends Controller
 
         $otp = random_int(100000, 999999);
         cache()->put("otp:{$request->phone}", $otp, now()->addMinutes(5));
+        cache()->put("otp_attempts:{$request->phone}", 0, now()->addMinutes(5));
 
         $response = Textify::via(config('textify.default'))
             ->fallback(config('textify.fallback'))
             ->to($request->phone)
             ->message(__('Your verification code is :code. Valid for 5 minutes.', ['code' => $otp]))
-            ->send();
+            ->sendWithFallback();
 
         if ($response->isFailed()) {
             return back()->withErrors(['phone' => __('Failed to send OTP. Please try again.')]);
@@ -359,11 +360,31 @@ class OtpController extends Controller
             'otp' => 'required|digits:6',
         ]);
 
+        // Rate limit: max 5 attempts per phone number
+        $attemptsKey = "otp_attempts:{$request->phone}";
+        $attempts = (int) cache()->get($attemptsKey, 0);
+
+        if ($attempts >= 5) {
+            cache()->forget("otp:{$request->phone}");
+            cache()->forget($attemptsKey);
+
+            return back()->withErrors(['otp' => __('Too many attempts. Please request a new OTP.')]);
+        }
+
+        cache()->increment($attemptsKey);
+
         $cached = cache()->pull("otp:{$request->phone}");
 
         if (!$cached || (int) $request->otp !== $cached) {
+            // Put back so subsequent attempts can still match (pull removes it)
+            if ($cached) {
+                cache()->put("otp:{$request->phone}", $cached, now()->addMinutes(5));
+            }
+
             return back()->withErrors(['otp' => __('Invalid or expired OTP.')]);
         }
+
+        cache()->forget($attemptsKey);
 
         // OTP verified — proceed with action
     }
@@ -473,7 +494,7 @@ php artisan textify:table                                    # Publish activity 
 |---|---|
 | Instantiating providers directly | Use `Textify::` facade or `Textify::via('name')` |
 | Sending SMS synchronously in web requests for non-critical messages | Use `->queue()` for non-critical SMS |
-| No fallback for OTP/critical messages | ALWAYS use `->fallback('provider')` |
+| No fallback for OTP/critical messages | Use `->fallback('provider')->sendWithFallback()` |
 | Hardcoding `Textify::via('dhorola')` everywhere | Set `TEXTIFY_PROVIDER` in `.env`, use default |
 | Running real SMS in tests | Set `TEXTIFY_PROVIDER=array` in test env |
 | Not checking `$response->isSuccessful()` | ALWAYS check response and handle failures |


### PR DESCRIPTION
## Summary
Addresses the 4 review comments from Copilot on PR #15:

- **Immutability claim**: Corrected wording — `via()`, `to()`, `message()`, `from()` return clones, but `fallback()` mutates the instance
- **Fallback + send()**: Changed all `->send()` calls to `->sendWithFallback()` in fallback examples, since `send()` does not trigger fallback logic
- **ArrayProvider namespace**: Fixed import from `DevWizard\Textify\Providers\Development\ArrayProvider` to `DevWizard\Textify\Providers\ArrayProvider`, and updated assertions to use array access (`$messages[0]['message']`) instead of object methods
- **OTP brute-force protection**: Added per-phone attempt counting with max 5 attempts and lockout to the OTP verification example

## Test plan
- [ ] Verify all code examples in SKILL.md match the actual package API
- [ ] Confirm `sendWithFallback()` is the correct method for fallback routing
- [ ] Confirm `ArrayProvider` lives at `DevWizard\Textify\Providers\ArrayProvider`

🤖 Generated with [Claude Code](https://claude.com/claude-code)